### PR TITLE
Fix DEP0128 warning/error (deprecation since NodeJS v16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@toyokumo/prettier-config",
   "version": "1.0.1",
   "description": "Prettier config for Toyokumo",
-  "main": "index.js",
+  "main": "index.json",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "release": "standard-version"


### PR DESCRIPTION
When prettier was run with configuration in this repository, the warning message like below would be shown:

```
(node:31263) [DEP0128] DeprecationWarning: Invalid 'main' field in 'node_modules/@toyokumo/prettier-config/package.json' of 'index.js'.
```

This is because some patterns of `main` value in package.json would be deprecated.

https://nodejs.org/api/deprecations.html#DEP0128
> Modules that have an invalid main entry (e.g., ./does-not-exist.js) and also have an index.js file in the top level directory will resolve the index.js file. That is deprecated and is going to throw an error in future Node.js versions.

This PR solves the deprecation above with specifying the existing file (`index.json`) for `main` in package.json, and works fine (without any deprecations) as far as I tested.
