### PR TITLE
Set graphql tabWidth to 4

### DIFF
--- a/index.json
+++ b/index.json
@@ -13,6 +13,12 @@
       "options": {
         "singleQuote": true
       }
+    },
+    {
+      "files": ["*.graphql"],
+      "options": {
+        "tabWidth": 4
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR aims to ensure `*.graphql` files to be formatted with tabWidth:4 and prevent unnecessary diffs.

# Checked
- this settings makes an effect and actually format .graphql files to 4 space indented style, on my local project.